### PR TITLE
Do not require "Delete portal content" for copying.

### DIFF
--- a/collective/deletepermission/configure.zcml
+++ b/collective/deletepermission/configure.zcml
@@ -27,6 +27,13 @@
       />
 
   <monkey:patch
+      description="Patch cb_isCopyable"
+      class="OFS.CopySupport.CopySource"
+      original="cb_isCopyable"
+      replacement="collective.deletepermission.copy.cb_isCopyable"
+      />
+
+  <monkey:patch
       description="Patch manage_renameObject"
       class="OFS.CopySupport.CopyContainer"
       original="manage_renameObject"

--- a/collective/deletepermission/copy.py
+++ b/collective/deletepermission/copy.py
@@ -1,0 +1,18 @@
+from AccessControl import getSecurityManager
+from AccessControl.Permissions import copy_or_move
+
+
+# origin: OFS.CopySupport.cb_isCopyable
+# Change: the cb_userHasCopyOrMovePermission is patched in .cut_object
+# and requires "Delete portal content" so that cutting works as it is
+# excpected.
+# Since copying should not require "Delete portal content" we directly
+# check the permission and no longer use cb_userHasCopyOrMovePermission.
+def cb_isCopyable(self):
+    # Is object copyable? Returns 0 or 1
+    if not (hasattr(self, '_canCopy') and self._canCopy(0)):
+        return 0
+    # if not self.cb_userHasCopyOrMovePermission():
+    if not getSecurityManager().checkPermission(copy_or_move, self):
+        return 0
+    return 1

--- a/collective/deletepermission/testing.py
+++ b/collective/deletepermission/testing.py
@@ -1,15 +1,18 @@
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import applyProfile
 from plone.app.testing import setRoles, TEST_USER_ID, TEST_USER_NAME, login
 from zope.configuration import xmlconfig
-from plone.app.testing import applyProfile
 
 
 class CollectiveDeletepermissionLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         # Load ZCML
@@ -33,5 +36,6 @@ COLLECTIVE_DELETEPERMISSION_INTEGRATION_TESTING = IntegrationTesting(
     bases=(COLLECTIVE_DELETEPERMISSION_FIXTURE, ),
     name="CollectiveDeletepermission:Integration")
 COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(COLLECTIVE_DELETEPERMISSION_FIXTURE, ),
+    bases=(COLLECTIVE_DELETEPERMISSION_FIXTURE,
+           set_builder_session_factory(functional_session_factory)),
     name="CollectiveDeletepermission:Functional")

--- a/collective/deletepermission/tests/test_copy.py
+++ b/collective/deletepermission/tests/test_copy.py
@@ -1,0 +1,40 @@
+from AccessControl import Unauthorized
+from Products.statusmessages.interfaces import IStatusMessage
+from collective.deletepermission import testing
+from ftw.builder import Builder
+from ftw.builder import create
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+
+
+class TestCopy(TestCase):
+
+    layer = testing.COLLECTIVE_DELETEPERMISSION_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Contributor'])
+        login(self.portal, TEST_USER_NAME)
+
+    def test_copy_works_without_beeing_able_to_delete(self):
+        folder = create(Builder('folder'))
+        self.revoke_permission('Delete portal content', on=folder)
+        folder.object_copy()
+        self.assertEquals([u'folder copied.'], self.get_status_messages())
+
+    def test_copy_denied_without_copy_or_move_permission(self):
+        folder = create(Builder('folder'))
+        self.revoke_permission('Copy or Move', on=folder)
+        with self.assertRaises(Unauthorized):
+            folder.object_copy()
+
+    def revoke_permission(self, permission, on):
+        on.manage_permission(permission, roles=[], acquire=False)
+
+    def get_status_messages(self):
+        request = self.layer['request']
+        messages = [msg.message for msg in IStatusMessage(request).show()]
+        return messages

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Copy no longer requires "Delete portal content".
+  Requiring "Delete portal content" was introduced accidentally
+  for copying because of a patch for cutting.
+  [jone]
 
 
 1.1.1 (2013-06-04)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ tests_require = [
     'transaction',
     'unittest2',
     'zope.configuration',
+    'ftw.builder',
     ]
 
 


### PR DESCRIPTION
Requiring "Delete portal content" was introduced accidentally for copying because of a patch for cutting.

Patch `OFS.CopySupport.cb_isCopyable` to no longer use the patched `cb_userHasCopyOrMovePermission`, which was patched to also require `Delete portal content` so that cutting works properly.

I decided to change `cb_isCopyable` rather than `cb_userHasCopyOrMovePermission` (and the cutting process) because I think it is safer to not introduce more problems with cutting.

@maethu @buchi can you take a look?
/cc @elioschmutz
