### PR TITLE
Fix protection of manage_delObjects with "Delete objects".

### DIFF
--- a/collective/deletepermission/del_object.py
+++ b/collective/deletepermission/del_object.py
@@ -1,17 +1,21 @@
-from Products.CMFCore.PortalFolder import PortalFolderBase as PortalFolder
 from AccessControl import Unauthorized
 from AccessControl import getSecurityManager
+from Products.CMFCore.PortalFolder import PortalFolderBase as PortalFolder
 
 
 def manage_delObjects(self, ids=None, REQUEST=None):
     """We need to enforce security."""
+    sm = getSecurityManager()
+    if not sm.checkPermission('Delete objects', self):
+        raise Unauthorized(
+            "Do not have permissions to remove this object")
+
     if ids is None:
         ids = []
     if isinstance(ids, basestring):
         ids = [ids]
     for id_ in ids:
         item = self._getOb(id_)
-        sm = getSecurityManager()
         if not sm.checkPermission("Delete portal content", item):
             raise Unauthorized(
                 "Do not have permissions to remove this object")

--- a/collective/deletepermission/tests/test_delete.py
+++ b/collective/deletepermission/tests/test_delete.py
@@ -1,0 +1,60 @@
+from collective.deletepermission import testing
+from ftw.builder import Builder
+from ftw.builder import create
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from unittest2 import TestCase
+from zExceptions import Unauthorized
+
+
+class TestDeleeting(TestCase):
+    layer = testing.COLLECTIVE_DELETEPERMISSION_INTEGRATION_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Contributor'])
+        login(self.layer['portal'], TEST_USER_NAME)
+
+    def test_delete_possible_with_both_permissions(self):
+        parent = create(Builder('folder'))
+        child = create(Builder('folder').within(parent))
+
+        parent.manage_permission('Delete objects',
+                                 roles=['Contributor'], acquire=False)
+        child.manage_permission('Delete portal content',
+                                roles=['Contributor'], acquire=False)
+
+        self.assertIn(child.getId(), parent.objectIds())
+        parent.manage_delObjects([child.getId()])
+        self.assertNotIn(child.getId(), parent.objectIds())
+
+    def test_delete_unauthorized_when_no_permission_on_child(self):
+        parent = create(Builder('folder'))
+        child = create(Builder('folder').within(parent))
+
+        parent.manage_permission('Delete objects',
+                                 roles=['Contributor'], acquire=False)
+        child.manage_permission('Delete portal content',
+                                roles=[], acquire=False)
+
+        with self.assertRaises(Unauthorized):
+            parent.manage_delObjects([child.getId()])
+
+    def test_delete_unauthorized_when_no_permission_on_parent(self):
+        parent = create(Builder('folder'))
+        child = create(Builder('folder').within(parent))
+
+        from AccessControl import getSecurityManager
+        sm = getSecurityManager()
+        self.assertEqual(1, sm.checkPermission('Delete objects', parent))
+
+        parent.manage_permission('Delete objects',
+                                 roles=[], acquire=False)
+        child.manage_permission('Delete portal content',
+                                roles=['Contributor'], acquire=False)
+
+        self.assertEqual(None, sm.checkPermission('Delete objects', parent))
+
+        with self.assertRaises(Unauthorized):
+            parent.manage_delObjects([child.getId()])

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,12 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix protection of manage_delObjects with "Delete objects".
+  In certain situations, when only having the permission to delete the
+  content ("Delete portal content") but not the permission to delete from the
+  the parent container ("Delete objects" on the parent) deleting was possible
+  even though it shouldn't have been.
+  [jone]
 
 
 1.1.2 (2013-10-17)


### PR DESCRIPTION
In certain situations, when only having the permission to delete the
content ("Delete portal content") but not the permission to delete from the
the parent container ("Delete objects" on the parent) deleting was possible
even though it shouldn't have been.

This should not be that problematic since the user alyways needed the
"Delete portal content" permission on the item.

@maethu @buchi can you review this one?
/cc @Tschanzt 
