### PR TITLE
Refactor tests to use ftw.testbrowser and ftw.builder

### DIFF
--- a/collective/deletepermission/testing.py
+++ b/collective/deletepermission/testing.py
@@ -61,10 +61,6 @@ class CollectiveDeletepermissionDXLayer(PloneSandboxLayer):
 COLLECTIVE_DELETEPERMISSION_FIXTURE = CollectiveDeletepermissionLayer()
 COLLECTIVE_DELETEPERMISSION_DX_FIXTURE = CollectiveDeletepermissionDXLayer()
 
-COLLECTIVE_DELETEPERMISSION_INTEGRATION_TESTING = IntegrationTesting(
-    bases=(COLLECTIVE_DELETEPERMISSION_FIXTURE, ),
-    name="CollectiveDeletepermission:Integration")
-
 COLLECTIVE_DELETEPERMISSION_DX_INTEGRATION_TESTING = IntegrationTesting(
     bases=(COLLECTIVE_DELETEPERMISSION_DX_FIXTURE, ),
     name="CollectiveDeletepermissionDX:Integration")

--- a/collective/deletepermission/tests/base.py
+++ b/collective/deletepermission/tests/base.py
@@ -1,0 +1,16 @@
+from collective.deletepermission import testing
+from Products.statusmessages.interfaces import IStatusMessage
+from unittest2 import TestCase
+
+
+class FunctionalTestCase(TestCase):
+
+    layer = testing.COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
+
+    def revoke_permission(self, permission, on):
+        on.manage_permission(permission, roles=[], acquire=False)
+
+    def get_status_messages(self):
+        request = self.layer['request']
+        messages = [msg.message for msg in IStatusMessage(request).show()]
+        return messages

--- a/collective/deletepermission/tests/base.py
+++ b/collective/deletepermission/tests/base.py
@@ -6,6 +6,7 @@ from ftw.testbrowser import browser
 from plone.app.testing import login
 from Products.statusmessages.interfaces import IStatusMessage
 from unittest2 import TestCase
+import transaction
 
 
 class FunctionalTestCase(TestCase):
@@ -14,6 +15,14 @@ class FunctionalTestCase(TestCase):
 
     def revoke_permission(self, permission, on):
         on.manage_permission(permission, roles=[], acquire=False)
+
+    def set_local_roles(self, context, user, *roles):
+        if hasattr(user, 'getUserName'):
+            user = user.getUserName()
+
+        context.manage_setLocalRoles(user, tuple(roles))
+        context.reindexObjectSecurity()
+        transaction.commit()
 
     def get_status_messages(self):
         request = self.layer['request']

--- a/collective/deletepermission/tests/base.py
+++ b/collective/deletepermission/tests/base.py
@@ -1,4 +1,9 @@
+from AccessControl.SecurityManagement import getSecurityManager
+from AccessControl.SecurityManagement import setSecurityManager
 from collective.deletepermission import testing
+from contextlib import contextmanager
+from ftw.testbrowser import browser
+from plone.app.testing import login
 from Products.statusmessages.interfaces import IStatusMessage
 from unittest2 import TestCase
 
@@ -14,3 +19,18 @@ class FunctionalTestCase(TestCase):
         request = self.layer['request']
         messages = [msg.message for msg in IStatusMessage(request).show()]
         return messages
+
+    def get_actions(self):
+        return browser.css('#plone-contentmenu-actions .actionMenuContent a').text
+
+    @contextmanager
+    def user(self, username):
+        if hasattr(username, 'getUserName'):
+            username = username.getUserName()
+
+        sm = getSecurityManager()
+        login(self.layer['portal'], username)
+        try:
+            yield
+        finally:
+            setSecurityManager(sm)

--- a/collective/deletepermission/tests/test_actions.py
+++ b/collective/deletepermission/tests/test_actions.py
@@ -1,117 +1,62 @@
-from Products.CMFCore.utils import getToolByName
-from collective.deletepermission import testing
-from lxml.cssselect import CSSSelector
-from plone.app.testing import SITE_OWNER_NAME
-from plone.app.testing import login
-from plone.app.testing import logout
-from plone.testing.z2 import Browser
-from unittest2 import TestCase
-from zope.container.interfaces import INameChooser
-import lxml.html
+from collective.deletepermission.tests.base import FunctionalTestCase
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
 import transaction
 
 
-class ActionTestBase(TestCase):
-
-    def create_user(self, with_id, identified_by='password', with_roles=None):
-        if with_roles is None:
-            with_roles = ['Member']
-
-        acl_users = getToolByName(self.layer['portal'], 'acl_users')
-        acl_users.userFolderAddUser(with_id, identified_by, with_roles, [])
-
-    def given_object(self, titled, creator, within=None, of_type='Folder'):
-        if within is None:
-            within = self.layer['portal']
-
-        login(self.layer['portal'], creator)
-
-        chooser = INameChooser(within)
-        newid = chooser.chooseName(titled, within)
-        within.invokeFactory(of_type, newid, title=titled)
-        obj = within.get(newid)
-        obj.processForm()
-
-        transaction.commit()
-
-        logout()
-        return obj
-
-    def open_browser(self, visit, as_user=SITE_OWNER_NAME,
-                     identifed_by='password'):
-
-        self.browser = Browser(self.layer['app'])
-        self.browser.handleErrors = False
-        self.browser.addHeader('Authorization', 'Basic %s:%s' % (
-                as_user, identifed_by))
-        self.browser.open(visit.absolute_url())
-
-    def get_actions(self):
-        html = lxml.html.fromstring(self.browser.contents)
-        xpath = CSSSelector('#plone-contentmenu-actions a span').path
-        elements = html.xpath(xpath)
-        return [element.text_content().strip() for element in elements]
-
-
-class TestDeleteAction(ActionTestBase):
-
-    layer = testing.COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
+class TestDeleteAction(FunctionalTestCase):
 
     def setUp(self):
-        self.create_user(with_id='hans', with_roles=['Member', 'Contributor'])
-        self.create_user(with_id='peter',
-                         with_roles=['Member', 'Contributor'])
+        self.hugo = create(Builder('user').named('Hugo', 'Boss')
+                           .with_roles('Member', 'Contributor'))
+        self.john = create(Builder('user').named('John', 'Doe')
+                           .with_roles('Member', 'Contributor'))
+        with self.user(self.hugo):
+            self.container = create(Builder('folder'))
+        with self.user(self.john):
+            self.content = create(Builder('folder').within(self.container))
 
-    def test_user_can_delete_own_contents(self):
-        container = self.given_object(titled='Container', creator='hans')
-        content = self.given_object(titled='Content',
-                                    within=container, creator='peter')
-
-        self.open_browser(visit=content, as_user='peter')
+    @browsing
+    def test_user_can_delete_own_contents(self, browser):
+        browser.login(self.john).visit(self.content)
         self.assertIn('Delete', self.get_actions(),
                       'A user should be able to delete his own content.')
 
-    def test_user_can_not_delete_without_delete_objects_on_parent(self):
-        container = self.given_object(titled='Container', creator='hans')
-        content = self.given_object(titled='Content',
-                                    within=container, creator='peter')
-
-        container.manage_permission('Delete objects', roles=[], acquire=False)
+    @browsing
+    def test_user_can_not_delete_without_delete_objects_on_parent(self,
+                                                                  browser):
+        self.revoke_permission('Delete objects', on=self.container)
         transaction.commit()
-
-        self.open_browser(visit=content, as_user='peter')
+        browser.login(self.john).visit(self.content)
         self.assertNotIn('Delete', self.get_actions(),
                          'A user should not be able to delete content'
                          ' without "Delete objects" on the parent.')
 
 
-class TestCutAction(ActionTestBase):
-
-    layer = testing.COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
+class TestCutAction(FunctionalTestCase):
 
     def setUp(self):
-        self.create_user(with_id='hans', with_roles=['Member', 'Contributor'])
-        self.create_user(with_id='peter',
-                         with_roles=['Member', 'Contributor'])
+        self.hugo = create(Builder('user').named('Hugo', 'Boss')
+                           .with_roles('Member', 'Contributor'))
+        self.john = create(Builder('user').named('John', 'Doe')
+                           .with_roles('Member', 'Contributor'))
+        with self.user(self.hugo):
+            self.container = create(Builder('folder'))
+        with self.user(self.john):
+            self.content = create(Builder('folder').within(self.container))
 
-    def test_user_can_cut_own_contents(self):
-        container = self.given_object(titled='Container', creator='hans')
-        content = self.given_object(titled='Content',
-                                    within=container, creator='peter')
-
-        self.open_browser(visit=content, as_user='peter')
+    @browsing
+    def test_user_can_cut_own_contents(self, browser):
+        browser.login(self.john).visit(self.content)
         self.assertIn('Cut', self.get_actions(),
                       'A user should be able to cut his own content.')
 
-    def test_user_can_not_cut_without_delete_objects_on_parent(self):
-        container = self.given_object(titled='Container', creator='hans')
-        content = self.given_object(titled='Content',
-                                    within=container, creator='peter')
-
-        container.manage_permission('Delete objects', roles=[], acquire=False)
+    @browsing
+    def test_user_can_not_cut_without_delete_objects_on_parent(self, browser):
+        self.revoke_permission('Delete objects', on=self.container)
         transaction.commit()
-
-        self.open_browser(visit=content, as_user='peter')
+        browser.login(self.john).visit(self.content)
         self.assertNotIn('Cut', self.get_actions(),
                          'A user should not be able to cut content'
                          ' without "Delete objects" on the parent.')

--- a/collective/deletepermission/tests/test_copy.py
+++ b/collective/deletepermission/tests/test_copy.py
@@ -1,18 +1,14 @@
 from AccessControl import Unauthorized
-from Products.statusmessages.interfaces import IStatusMessage
-from collective.deletepermission import testing
+from collective.deletepermission.tests.base import FunctionalTestCase
 from ftw.builder import Builder
 from ftw.builder import create
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
-from unittest2 import TestCase
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
 
 
-class TestCopy(TestCase):
-
-    layer = testing.COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
+class TestCopy(FunctionalTestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
@@ -30,11 +26,3 @@ class TestCopy(TestCase):
         self.revoke_permission('Copy or Move', on=folder)
         with self.assertRaises(Unauthorized):
             folder.object_copy()
-
-    def revoke_permission(self, permission, on):
-        on.manage_permission(permission, roles=[], acquire=False)
-
-    def get_status_messages(self):
-        request = self.layer['request']
-        messages = [msg.message for msg in IStatusMessage(request).show()]
-        return messages

--- a/collective/deletepermission/tests/test_copy.py
+++ b/collective/deletepermission/tests/test_copy.py
@@ -12,7 +12,7 @@ from unittest2 import TestCase
 
 class TestCopy(TestCase):
 
-    layer = testing.COLLECTIVE_DELETEPERMISSION_INTEGRATION_TESTING
+    layer = testing.COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.portal = self.layer['portal']

--- a/collective/deletepermission/tests/test_correct_permission.py
+++ b/collective/deletepermission/tests/test_correct_permission.py
@@ -1,91 +1,70 @@
-from collective.deletepermission.testing import COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
-from unittest2 import TestCase
-from Products.CMFCore.utils import getToolByName
-from plone.app.testing import login
-from plone.app.testing import logout
 from AccessControl import Unauthorized
+from collective.deletepermission.tests.base import FunctionalTestCase
+from ftw.builder import Builder
+from ftw.builder import create
 
 
-class TestCorrectPermissions(TestCase):
-
-    layer = COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
+class TestCorrectPermissions(FunctionalTestCase):
 
     def setUp(self):
-        self.portal = self.layer['portal']
-        regtool = getToolByName(self.portal, 'portal_registration')
+        self.user_a = create(Builder('user').with_userid('usera'))
+        self.user_b = create(Builder('user').with_userid('userb'))
 
-        #add members
-        regtool.addMember('usera', 'usera',
-                          properties={'username': 'usera',
-                                      'fullname': 'f\xc3\xbcllnamea',
-                                      'email': 'usera@email.com'})
+        self.folder = create(Builder('folder').titled('rootfolder'))
+        self.set_local_roles(self.folder, self.user_a, 'Contributor')
+        self.set_local_roles(self.folder, self.user_b, 'Contributor')
 
-        regtool.addMember('userb', 'userb',
-                          properties={'username': 'userb',
-                                      'fullname': 'f\xc3\xbcllnameb',
-                                      'email': 'userb@email.com'})
-        #create structure
-        self.folder = self.portal.get(
-            self.portal.invokeFactory('Folder', 'rootfolder'))
-        self.folder.manage_addLocalRoles('usera', ['Contributor'])
-        self.folder.manage_addLocalRoles('userb', ['Contributor'])
-        logout()
+        with self.user(self.user_a):
+            self.folder_a = create(Builder('folder').within(self.folder)
+                                   .with_id('folder-a'))
+            self.doc_a = create(Builder('document').within(self.folder_a)
+                                .with_id('doc-a'))
 
-        login(self.portal, 'usera')
-        #create a folder and a document as usera
-        self.folder_a = self.folder.get(
-            self.folder.invokeFactory('Folder', 'folder-a'))
-        self.doc_a = self.folder_a.get(
-            self.folder_a.invokeFactory('Document', 'doc-a'))
-        logout()
-
-        #create a doc as userb
-        login(self.portal, 'userb')
-        self.doc_b = self.folder_a.get(
-            self.folder_a.invokeFactory('Document', 'doc-b'))
-        logout()
+        with self.user(self.user_b):
+            self.doc_b = create(Builder('document').within(self.folder_a)
+                                .with_id('doc-b'))
 
     def test_usera_remove_folder(self):
         """Test if usera can remove his folder"""
-        login(self.portal, 'usera')
-        self.folder.manage_delObjects('folder-a')
+        with self.user(self.user_a):
+            self.folder.manage_delObjects('folder-a')
 
     def test_userb_remove_folder(self):
         """Test if userb can't delete usera's folder"""
-        login(self.portal, 'userb')
-        self.assertRaises(Unauthorized,
-                          self.folder.manage_delObjects,
-                          'folder-a')
+        with self.user(self.user_b):
+            self.assertRaises(Unauthorized,
+                              self.folder.manage_delObjects,
+                              'folder-a')
 
     def test_usera_remove_doc_a(self):
         """Test if usera can remove his doc"""
-        login(self.portal, 'usera')
-        self.folder_a.manage_delObjects('doc-a')
+        with self.user(self.user_a):
+            self.folder_a.manage_delObjects('doc-a')
 
     def test_usera_remove_doc_b(self):
         """Test if usera can remove userb's folder"""
-        login(self.portal, 'usera')
-        self.folder_a.manage_delObjects('doc-b')
+        with self.user(self.user_a):
+            self.folder_a.manage_delObjects('doc-b')
 
     def test_userb_remove_doc_a(self):
         """Test if userb can remove usera's folder"""
-        login(self.portal, 'userb')
-        self.assertRaises(Unauthorized,
-                          self.folder_a.manage_delObjects,
-                          'doc-a')
+        with self.user(self.user_b):
+            self.assertRaises(Unauthorized,
+                              self.folder_a.manage_delObjects,
+                              'doc-a')
 
     def test_userb_remove_doc_b(self):
         """Test if userb can remove his doc"""
-        login(self.portal, 'userb')
-        self.folder_a.manage_delObjects('doc-b')
+        with self.user(self.user_b):
+            self.folder_a.manage_delObjects('doc-b')
 
     def test_remove_multiple(self):
         """Test if we still are able to remove multiple objects at once."""
-        login(self.portal, 'usera')
-        self.folder_a.manage_delObjects(['doc-a', 'doc-b'])
-        self.assertEqual(self.folder_a.objectIds(), [])
+        with self.user(self.user_a):
+            self.folder_a.manage_delObjects(['doc-a', 'doc-b'])
+            self.assertEqual(self.folder_a.objectIds(), [])
 
     def test_remove_empty(self):
         """Check that we don't throw errors if we get a id that is none'"""
-        login(self.portal, 'usera')
-        self.folder_a.manage_delObjects(None)
+        with self.user(self.user_a):
+            self.folder_a.manage_delObjects(None)

--- a/collective/deletepermission/tests/test_correct_permission.py
+++ b/collective/deletepermission/tests/test_correct_permission.py
@@ -1,4 +1,4 @@
-from collective.deletepermission.testing import COLLECTIVE_DELETEPERMISSION_INTEGRATION_TESTING
+from collective.deletepermission.testing import COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
 from unittest2 import TestCase
 from Products.CMFCore.utils import getToolByName
 from plone.app.testing import login
@@ -8,7 +8,7 @@ from AccessControl import Unauthorized
 
 class TestCorrectPermissions(TestCase):
 
-    layer = COLLECTIVE_DELETEPERMISSION_INTEGRATION_TESTING
+    layer = COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.portal = self.layer['portal']

--- a/collective/deletepermission/tests/test_creation.py
+++ b/collective/deletepermission/tests/test_creation.py
@@ -1,47 +1,23 @@
-from collective.deletepermission import testing
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.testing import setRoles
-from plone.testing.z2 import Browser
-from unittest2 import TestCase
+from collective.deletepermission.tests.base import FunctionalTestCase
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import plone
+from ftw.testbrowser.pages import statusmessages
 import transaction
 
 
-class TestFactoryPatch(TestCase):
+class TestFactoryPatch(FunctionalTestCase):
 
-    layer = testing.COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
-
-    def test_object_addable_without_delete_permission(self):
-        portal = self.layer['portal']
-        self.revoke_permission('Delete portal content', on=portal)
-        self.grant_roles('Contributor')
+    @browsing
+    def test_object_addable_without_delete_permission(self, browser):
+        user = create(Builder('user').with_roles('Contributor'))
+        self.revoke_permission('Delete portal content', on=self.layer['portal'])
         transaction.commit()
 
-        self.visit(portal.absolute_url() +
-                   '/createObject?type_name=Folder')
-        self.fill('Title', 'Foo')
-        self.save()
-        self.assert_url('http://nohost/plone/foo')
-
-    def revoke_permission(self, permission, on):
-        on.manage_permission(permission, roles=[], acquire=False)
-
-    def grant_roles(self, *roles):
-        setRoles(self.layer['portal'], TEST_USER_ID, roles)
-
-    def visit(self, url):
-        self.browser = Browser(self.layer['app'])
-        self.browser.addHeader('Authorization', 'Basic %s:%s' % (
-                TEST_USER_NAME, TEST_USER_PASSWORD,))
-        self.browser.handleErrors = False
-        self.browser.open(url)
-
-    def fill(self, label, value):
-        self.browser.getControl(label=label).value = value
-
-    def save(self):
-        self.browser.getControl(label='Save').click()
-
-    def assert_url(self, url, msg=None):
-        self.assertEquals(url.rstrip('/'), self.browser.url.rstrip('/'), msg)
+        browser.login(user).open()
+        factoriesmenu.add('Folder')
+        browser.fill({'Title': 'Foo'}).save()
+        statusmessages.assert_no_error_messages()
+        self.assertEquals(('folder_listing', 'folder'), plone.view_and_portal_type())

--- a/collective/deletepermission/tests/test_cut_permission.py
+++ b/collective/deletepermission/tests/test_cut_permission.py
@@ -1,103 +1,72 @@
-from collective.deletepermission.testing import (
-    COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING)
-from unittest2 import TestCase
-from Products.CMFCore.utils import getToolByName
-from plone.app.testing import login
-from plone.app.testing import logout
+from collective.deletepermission.tests.base import FunctionalTestCase
+from ftw.builder import Builder
+from ftw.builder import create
 from OFS.CopySupport import CopyError
 
-import transaction
 
-
-class TestCorrectPermissions(TestCase):
-
-    layer = COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
+class TestCorrectPermissions(FunctionalTestCase):
 
     def setUp(self):
-        self.portal = self.layer['portal']
-        regtool = getToolByName(self.portal, 'portal_registration')
+        self.user_a = create(Builder('user').with_userid('usera'))
+        self.user_b = create(Builder('user').with_userid('userb'))
 
-        #add members
-        regtool.addMember('usera', 'usera',
-                          properties={'username': 'usera',
-                                      'fullname': 'f\xc3\xbcllnamea',
-                                      'email': 'usera@email.com'})
+        self.folder = create(Builder('folder').titled('rootfolder'))
+        self.set_local_roles(self.folder, self.user_a, 'Contributor')
+        self.set_local_roles(self.folder, self.user_b, 'Contributor')
 
-        regtool.addMember('userb', 'userb',
-                          properties={'username': 'userb',
-                                      'fullname': 'f\xc3\xbcllnameb',
-                                      'email': 'userb@email.com'})
-        #create structure
-        self.folder = self.portal.get(
-            self.portal.invokeFactory('Folder', 'rootfolder'))
-        self.folder.manage_addLocalRoles('usera', ['Contributor'])
-        self.folder.manage_addLocalRoles('userb', ['Contributor'])
-        logout()
+        with self.user(self.user_a):
+            self.folder_a = create(Builder('folder').within(self.folder)
+                                   .with_id('folder-a'))
+            self.doc_a = create(Builder('document').within(self.folder_a)
+                                .with_id('doc-a'))
 
-        login(self.portal, 'usera')
-        #create a folder and a document as usera
-        self.folder_a = self.folder.get(
-            self.folder.invokeFactory('Folder', 'folder-a'))
-        self.doc_a = self.folder_a.get(
-            self.folder_a.invokeFactory('Document', 'doc-a'))
-        logout()
-
-        #create a doc as userb
-        login(self.portal, 'userb')
-        self.doc_b = self.folder_a.get(
-            self.folder_a.invokeFactory('Document', 'doc-b'))
-        logout()
-
-        transaction.commit()
-
-        # | obj            | user a             | user b             |
-        # | folder-a       | Contributor, Owner | Contributor        |
-        # | folder-a/doc-a | Contributor, Owner | Contributor        |
-        # | folder-a/doc-b | Contributor        | Contributor, Owner |
+        with self.user(self.user_b):
+            self.doc_b = create(Builder('document').within(self.folder_a)
+                                .with_id('doc-b'))
 
     def test_usera_cut_folder(self):
         """usera should be able to cut his own folder
         becauase he is its Owner"""
 
-        login(self.portal, 'usera')
-        self.folder.manage_cutObjects(['folder-a'])
+        with self.user(self.user_a):
+            self.folder.manage_cutObjects(['folder-a'])
 
     def test_userb_cut_folder(self):
         """userb should NOT be able to cut usera's folder, because he is
         not its Owner"""
 
-        login(self.portal, 'userb')
-        self.assertRaises(CopyError,
-                          self.folder.manage_cutObjects,
-                          ['folder-a'])
+        with self.user(self.user_b):
+            self.assertRaises(CopyError,
+                              self.folder.manage_cutObjects,
+                              ['folder-a'])
 
     def test_usera_cut_doc_a(self):
         """usera should be able to cut doc-a, because he is its Owner"""
 
-        login(self.portal, 'usera')
-        self.folder_a.manage_cutObjects(['doc-a'])
+        with self.user(self.user_a):
+            self.folder_a.manage_cutObjects(['doc-a'])
 
     def test_usera_cut_doc_b(self):
         """usera should be able to cut doc-b, because ???????????????????"""
         # XXX why?
 
-        login(self.portal, 'usera')
-        self.folder_a.manage_cutObjects(['doc-b'])
+        with self.user(self.user_a):
+            self.folder_a.manage_cutObjects(['doc-b'])
 
     def test_userb_cut_doc_a(self):
         """userb should NOT be able to cut coc-a, because his not Owner"""
         # XXX should this be raised upon paste??
 
-        login(self.portal, 'userb')
-        self.assertRaises(CopyError,
-                          self.folder_a.manage_cutObjects,
-                          'doc-a')
+        with self.user(self.user_b):
+            self.assertRaises(CopyError,
+                              self.folder_a.manage_cutObjects,
+                              'doc-a')
 
     def test_userb_cut_doc_b(self):
         """userb should be able to cut his own document"""
 
-        login(self.portal, 'userb')
-        self.folder_a.manage_cutObjects(['doc-b'])
+        with self.user(self.user_b):
+            self.folder_a.manage_cutObjects(['doc-b'])
 
     def test_cut_multiple(self):
         """Cutting objects INCLUDING an object which cannot be cut should not
@@ -105,11 +74,11 @@ class TestCorrectPermissions(TestCase):
         cancelled because of the exception)
         """
 
-        login(self.portal, 'usera')
-        self.folder_a.manage_cutObjects(['doc-a', 'doc-b'])
+        with self.user(self.user_a):
+            self.folder_a.manage_cutObjects(['doc-a', 'doc-b'])
 
     def test_cut_empty(self):
         """Cutting "None" should throw a ValueError."""
 
-        login(self.portal, 'usera')
-        self.assertRaises(ValueError, self.folder_a.manage_cutObjects, None)
+        with self.user(self.user_a):
+            self.assertRaises(ValueError, self.folder_a.manage_cutObjects, None)

--- a/collective/deletepermission/tests/test_delete.py
+++ b/collective/deletepermission/tests/test_delete.py
@@ -10,7 +10,7 @@ from zExceptions import Unauthorized
 
 
 class TestDeleeting(TestCase):
-    layer = testing.COLLECTIVE_DELETEPERMISSION_INTEGRATION_TESTING
+    layer = testing.COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
 
     def setUp(self):
         setRoles(self.layer['portal'], TEST_USER_ID, ['Contributor'])

--- a/collective/deletepermission/tests/test_delete.py
+++ b/collective/deletepermission/tests/test_delete.py
@@ -1,60 +1,48 @@
-from collective.deletepermission import testing
+from AccessControl import getSecurityManager
+from collective.deletepermission.tests.base import FunctionalTestCase
 from ftw.builder import Builder
 from ftw.builder import create
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
-from unittest2 import TestCase
 from zExceptions import Unauthorized
 
 
-class TestDeleeting(TestCase):
-    layer = testing.COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
+class TestDeleeting(FunctionalTestCase):
 
     def setUp(self):
-        setRoles(self.layer['portal'], TEST_USER_ID, ['Contributor'])
-        login(self.layer['portal'], TEST_USER_NAME)
+        self.contributor = create(Builder('user').with_roles('Contributor'))
+        self.parent = create(Builder('folder'))
+        self.child = create(Builder('folder').within(self.parent))
 
     def test_delete_possible_with_both_permissions(self):
-        parent = create(Builder('folder'))
-        child = create(Builder('folder').within(parent))
-
-        parent.manage_permission('Delete objects',
+        self.parent.manage_permission('Delete objects',
                                  roles=['Contributor'], acquire=False)
-        child.manage_permission('Delete portal content',
+        self.child.manage_permission('Delete portal content',
                                 roles=['Contributor'], acquire=False)
 
-        self.assertIn(child.getId(), parent.objectIds())
-        parent.manage_delObjects([child.getId()])
-        self.assertNotIn(child.getId(), parent.objectIds())
+        with self.user(self.contributor):
+            self.assertIn(self.child.getId(), self.parent.objectIds())
+            self.parent.manage_delObjects([self.child.getId()])
+            self.assertNotIn(self.child.getId(), self.parent.objectIds())
 
     def test_delete_unauthorized_when_no_permission_on_child(self):
-        parent = create(Builder('folder'))
-        child = create(Builder('folder').within(parent))
+        self.parent.manage_permission('Delete objects',
+                                      roles=['Contributor'], acquire=False)
+        self.child.manage_permission('Delete portal content',
+                                     roles=[], acquire=False)
 
-        parent.manage_permission('Delete objects',
-                                 roles=['Contributor'], acquire=False)
-        child.manage_permission('Delete portal content',
-                                roles=[], acquire=False)
-
-        with self.assertRaises(Unauthorized):
-            parent.manage_delObjects([child.getId()])
+        with self.user(self.contributor):
+            with self.assertRaises(Unauthorized):
+                self.parent.manage_delObjects([self.child.getId()])
 
     def test_delete_unauthorized_when_no_permission_on_parent(self):
-        parent = create(Builder('folder'))
-        child = create(Builder('folder').within(parent))
+        with self.user(self.contributor):
+            checkPermission = getSecurityManager().checkPermission
+            self.assertTrue(checkPermission('Delete objects', self.parent))
 
-        from AccessControl import getSecurityManager
-        sm = getSecurityManager()
-        self.assertEqual(1, sm.checkPermission('Delete objects', parent))
+            self.parent.manage_permission('Delete objects',
+                                          roles=[], acquire=False)
+            self.child.manage_permission('Delete portal content',
+                                         roles=['Contributor'], acquire=False)
 
-        parent.manage_permission('Delete objects',
-                                 roles=[], acquire=False)
-        child.manage_permission('Delete portal content',
-                                roles=['Contributor'], acquire=False)
-
-        self.assertEqual(None, sm.checkPermission('Delete objects', parent))
-
-        with self.assertRaises(Unauthorized):
-            parent.manage_delObjects([child.getId()])
+            self.assertFalse(checkPermission('Delete objects', self.parent))
+            with self.assertRaises(Unauthorized):
+                self.parent.manage_delObjects([self.child.getId()])

--- a/collective/deletepermission/tests/test_permission_functional.py
+++ b/collective/deletepermission/tests/test_permission_functional.py
@@ -1,381 +1,278 @@
 from AccessControl import Unauthorized
-from collective.deletepermission.testing import (
-    COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING)
-from mechanize._mechanize import LinkNotFoundError
-from plone.app.testing import login
-from plone.app.testing import logout
-from plone.app.testing import TEST_USER_NAME
-from plone.testing.z2 import Browser
-from Products.CMFCore.utils import getToolByName
-from unittest2 import TestCase
-import transaction
+from collective.deletepermission.tests.base import FunctionalTestCase
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import folder_contents
+from ftw.testbrowser.pages import plone
+from ftw.testbrowser.pages import statusmessages
 
 
-class TestCorrectPermissions(TestCase):
-
-    layer = COLLECTIVE_DELETEPERMISSION_FUNCTIONAL_TESTING
+class TestCorrectPermissions(FunctionalTestCase):
 
     def setUp(self):
-        self.portal = self.layer['portal']
-        #add members
-        regtool = getToolByName(self.portal, 'portal_registration')
+        self.user_a = create(Builder('user').with_userid('usera'))
+        self.user_b = create(Builder('user').with_userid('userb'))
 
-        regtool.addMember('usera', 'usera',
-                          properties={'username': 'usera',
-                                      'fullname': 'f\xc3\xbcllnamea',
-                                      'email': 'usera@email.com'})
+        self.folder = create(Builder('folder').titled('rootfolder'))
+        self.set_local_roles(self.folder, self.user_a, 'Contributor')
+        self.set_local_roles(self.folder, self.user_b, 'Contributor')
 
-        regtool.addMember('userb', 'userb',
-                          properties={'username': 'userb',
-                                      'fullname': 'f\xc3\xbcllnameb',
-                                      'email': 'userb@email.com'})
-        #create folders
-        self.folder = self.portal.get(
-            self.portal.invokeFactory('Folder', 'rootfolder'))
-        self.folder.manage_addLocalRoles('usera', ['Contributor'])
-        self.folder.manage_addLocalRoles('userb', ['Contributor'])
-        logout()
+        with self.user(self.user_a):
+            self.folder_a = create(Builder('folder').within(self.folder)
+                                   .with_id('folder-a'))
+            self.doc_a = create(Builder('document').within(self.folder_a)
+                                .with_id('doc-a'))
 
-        #change user and create objects. We need to do this so the owner is
-        # set right.
-        login(self.portal, 'usera')
-        self.folder_a = self.folder.get(
-            self.folder.invokeFactory('Folder', 'folder-a'))
-        self.doc_a = self.folder_a.get(
-            self.folder_a.invokeFactory('Document', 'doc-a'))
-        logout()
+        with self.user(self.user_b):
+            self.doc_b = create(Builder('document').within(self.folder_a)
+                                .with_id('doc-b'))
 
-        login(self.portal, 'userb')
-        self.doc_b = self.folder_a.get(
-            self.folder_a.invokeFactory('Document', 'doc-b'))
-        logout()
-        transaction.commit()
-
-        self.browser = Browser(self.layer['app'])
-        self.browser.handleErrors = False
-
-    def tearDown(self):
-        super(TestCorrectPermissions, self).tearDown()
-        portal = self.layer['portal']
-        login(portal, TEST_USER_NAME)
-        portal.manage_delObjects(['rootfolder'])
-        transaction.commit()
-
-    def _auth_a(self):
-        self.browser.addHeader('Authorization', 'Basic %s:%s' % (
-            'usera', 'usera',))
-
-    def _auth_b(self):
-        self.browser.addHeader('Authorization', 'Basic %s:%s' % (
-            'userb', 'userb',))
-
-    def test_userb_delete_docb(self):
+    @browsing
+    def test_userb_delete_docb(self, browser):
         """
         Check if User B is able to delete his own document.
         """
-        self._auth_b()
+        browser.login(self.user_b).open(self.doc_b, view='delete_confirmation')
+        browser.find('Delete').click()
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/doc-b/delete_confirmation')
-        self.browser.getControl("Delete").click()
-
-    def test_userb_cut_docb(self):
+    @browsing
+    def test_userb_cut_docb(self, browser):
         """
         Check if User B is able to cut his own document.
         """
-        self._auth_b()
+        browser.login(self.user_b).open(self.doc_b)
+        browser.find('Cut').click()
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/doc-b')
-        link = self.browser.getLink("Cut")
-        self.assertTrue(link)
-
-        link.click()
-
-    def test_userb_rename_docb(self):
+    @browsing
+    def test_userb_rename_docb(self, browser):
         """
         Check if User B is able to rename his own document.
         """
-        self._auth_b()
+        browser.login(self.user_b).open(self.doc_b)
+        browser.find('Rename').click()
+        browser.fill({'new_ids:list': 'doc-b-renamed'}
+                     ).find('Rename All').click()
+        statusmessages.assert_no_error_messages()
+        self.assertEquals(self.folder_a.absolute_url() + '/doc-b-renamed',
+                          browser.url)
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/doc-b')
-        link = self.browser.getLink("Rename")
-        self.assertTrue(link)
-
-        link.click()
-
-        self.browser.getControl(name="new_ids:list").value = 'doc-b-renamed'
-        self.browser.getControl(name="form.button.RenameAll").click()
-
-        self.assertEquals(self.browser.url,
-            self.folder_a.absolute_url() + '/doc-b-renamed')
-
-    def test_usera_remove_folder(self):
+    @browsing
+    def test_usera_remove_folder(self, browser):
         """
         Test if User A is able to delete his folder
         """
-        self._auth_a()
+        browser.login(self.user_a).open(self.folder_a,
+                                        view='delete_confirmation')
+        browser.find('Delete').click()
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/delete_confirmation')
-        self.browser.getControl("Delete").click()
-
-    def test_usera_cut_folder(self):
+    @browsing
+    def test_usera_cut_folder(self, browser):
         """
         Test if User A is able to cut his folder
         """
-        self._auth_a()
+        browser.login(self.user_a).open(self.folder_a)
+        browser.find('Cut').click()
 
-        self.browser.open(self.folder_a.absolute_url())
-        link = self.browser.getLink("Cut")
-
-        self.assertTrue(link)
-        link.click()
-
-    def test_usera_rename_folder(self):
+    @browsing
+    def test_usera_rename_folder(self, browser):
         """
         Test if User A is able to rename his folder
         """
-        self._auth_a()
+        browser.login(self.user_a).open(self.folder_a)
+        browser.find('Rename').click()
+        browser.fill({'new_ids:list': 'folder-a-renamed'}
+                     ).find('Rename All').click()
+        statusmessages.assert_no_error_messages()
+        self.assertEquals(self.folder.absolute_url() + '/folder-a-renamed',
+                          browser.url)
 
-        self.browser.open(self.folder_a.absolute_url())
-        link = self.browser.getLink("Rename")
-
-        self.assertTrue(link)
-        link.click()
-
-        self.browser.getControl(name="new_ids:list").value = 'folder-a-renamed'
-        self.browser.getControl(name="form.button.RenameAll").click()
-
-        self.assertEquals(self.browser.url,
-            self.folder.absolute_url() + '/folder-a-renamed')
-
-    def test_userb_remove_folder(self):
+    @browsing
+    def test_userb_remove_folder(self, browser):
         """
         Check if User B can delete User A's folder. Should not be possible.
         """
-        self._auth_b()
+        browser.login(self.user_b).open(self.folder_a,
+                                        view='delete_confirmation')
+        with self.assertRaises(Unauthorized):
+            browser.find("Delete").click()
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/delete_confirmation')
-        self.assertRaises(Unauthorized,
-                          self.browser.getControl("Delete").click)
-
-    def test_userb_cut_folder(self):
+    @browsing
+    def test_userb_cut_folder(self, browser):
         """
         Check if User B can't cut User A's folder.
         """
-        self._auth_b()
-        self.browser.open(self.folder_a.absolute_url())
+        browser.login(self.user_b).open(self.folder_a)
+        self.assertNotIn('Cut', self.get_actions())
+        browser.open(self.folder_a, view='object_cut')
+        self.assertEquals(['folder-a is not moveable.'],
+                          statusmessages.error_messages())
 
-        self.assertRaises(LinkNotFoundError, self.browser.getLink, 'Cut')
-
-        self.assertRaises(Unauthorized,
-                          self.folder_a.restrictedTraverse('object_cut'))
-
-    def test_userb_rename_folder(self):
+    @browsing
+    def test_userb_rename_folder(self, browser):
         """
         Check if User B can't rename User A's folder.
         """
-        self._auth_b()
-        self.browser.open(self.folder_a.absolute_url())
+        browser.login(self.user_b).open(self.folder_a)
+        self.assertNotIn('Rename', self.get_actions())
+        with self.assertRaises(Unauthorized):
+            browser.open(self.folder_a, view='object_rename')
 
-        self.assertRaises(LinkNotFoundError, self.browser.getLink, 'Rename')
-
-        self.assertRaises(Unauthorized,
-                          self.folder_a.restrictedTraverse('object_rename'))
-
-    def test_usera_remove_doc_a(self):
+    @browsing
+    def test_usera_remove_doc_a(self, browser):
         """
         Test if User A is able to delete his own Document.
         """
-        self._auth_a()
+        browser.login(self.user_a).open(self.doc_a, view='delete_confirmation')
+        browser.find("Delete").click()
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/doc-a/delete_confirmation')
-        self.browser.getControl("Delete").click()
-
-    def test_usera_cut_doc_a(self):
+    @browsing
+    def test_usera_cut_doc_a(self, browser):
         """
         Test if User A is able to cut his own Document.
         """
-        self._auth_a()
+        browser.login(self.user_a).open(self.doc_a)
+        browser.find('Cut').click()
 
-        self.browser.open(self.doc_a.absolute_url())
-        link = self.browser.getLink('Cut')
-
-        self.assertTrue(link)
-        link.click()
-
-    def test_usera_rename_doc_a(self):
+    @browsing
+    def test_usera_rename_doc_a(self, browser):
         """
         Test if User A is able to rename his own Document.
         """
-        self._auth_a()
+        browser.login(self.user_a).open(self.doc_a)
+        browser.find('Rename').click()
+        browser.fill({'new_ids:list': 'doc-a-renamed',
+                      }).find('Rename All').click()
+        statusmessages.assert_no_error_messages()
+        self.assertEquals(self.folder_a.absolute_url() + '/doc-a-renamed',
+                          browser.url)
 
-        self.browser.open(self.doc_a.absolute_url())
-        link = self.browser.getLink('Rename')
-
-        self.assertTrue(link)
-        link.click()
-
-        self.browser.getControl(name="new_ids:list").value = 'doc-a-renamed'
-        self.browser.getControl(name="form.button.RenameAll").click()
-
-        self.assertEquals(self.browser.url,
-            self.folder_a.absolute_url() + '/doc-a-renamed')
-
-    def test_usera_remove_doc_b(self):
+    @browsing
+    def test_usera_remove_doc_b(self, browser):
         """
         Test if User A is able to delete the Document of User B
         """
-        self._auth_a()
+        browser.login(self.user_a).open(self.doc_b, view='delete_confirmation')
+        browser.find('Delete').click()
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/doc-b/delete_confirmation')
-        self.browser.getControl("Delete").click()
-
-    def test_usera_cut_doc_b(self):
+    @browsing
+    def test_usera_cut_doc_b(self, browser):
         """
         Test if User A is able to cut the Document of User B
         """
-        self._auth_a()
+        browser.login(self.user_a).open(self.doc_b)
+        browser.find('Cut').click()
 
-        self.browser.open(self.doc_b.absolute_url())
-        link = self.browser.getLink('Cut')
-
-        self.assertTrue(link)
-        link.click()
-
-    def test_usera_rename_doc_b(self):
+    @browsing
+    def test_usera_rename_doc_b(self, browser):
         """
         Test if User A is able to rename the Document of User B
         """
-        self._auth_a()
+        browser.login(self.user_a).open(self.doc_b)
+        browser.find('Rename').click()
+        browser.fill({'new_ids:list': 'doc-b-renamed',
+                      }).find('Rename All').click()
+        statusmessages.assert_no_error_messages()
+        self.assertEquals(self.folder_a.absolute_url() + '/doc-b-renamed',
+                          browser.url)
 
-        self.browser.open(self.doc_b.absolute_url())
-        link = self.browser.getLink('Rename')
-
-        self.assertTrue(link)
-        link.click()
-
-        self.browser.getControl(name="new_ids:list").value = 'doc-b-renamed'
-        self.browser.getControl(name="form.button.RenameAll").click()
-
-        self.assertEquals(self.browser.url,
-            self.folder_a.absolute_url() + '/doc-b-renamed')
-
-    def test_userb_remove_doc_a(self):
+    @browsing
+    def test_userb_remove_doc_a(self, browser):
         """
         Check if User B can remove User A's Document. Should not be possible.
         """
-        self._auth_b()
+        browser.login(self.user_b).open(self.doc_a, view='delete_confirmation')
+        with self.assertRaises(Unauthorized):
+            browser.find('Delete').click()
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/doc-a/delete_confirmation')
-        self.assertRaises(Unauthorized,
-                          self.browser.getControl("Delete").click)
-
-    def test_userb_cut_doc_a(self):
+    @browsing
+    def test_userb_cut_doc_a(self, browser):
         """
         Check if User B can't remove User A's Document.
         """
-        self._auth_b()
+        browser.login(self.user_b).open(self.doc_a)
+        self.assertNotIn('Cut', self.get_actions())
+        browser.open(self.doc_a, view='object_cut')
+        self.assertEquals(['doc-a is not moveable.'],
+                          statusmessages.error_messages())
 
-        self.browser.open(self.doc_a.absolute_url())
-
-        self.assertRaises(LinkNotFoundError, self.browser.getLink,
-                         'Cut')
-
-        self.assertRaises(Unauthorized,
-                          self.folder_a.restrictedTraverse('object_cut'))
-
-    def test_userb_rename_doc_a(self):
+    @browsing
+    def test_userb_rename_doc_a(self, browser):
         """
         Check if User B can't rename User A's Document.
         """
-        self._auth_b()
+        browser.login(self.user_b).open(self.doc_a)
+        self.assertNotIn('Rename', self.get_actions())
+        with self.assertRaises(Unauthorized):
+            browser.open(self.folder_a, view='object_rename')
 
-        self.browser.open(self.doc_a.absolute_url())
-
-        self.assertRaises(LinkNotFoundError, self.browser.getLink,
-                         'Rename')
-
-        self.assertRaises(Unauthorized,
-                          self.folder_a.restrictedTraverse('object_rename'))
-
-    def test_usera_remove_docs_folder_contents(self):
+    @browsing
+    def test_usera_remove_docs_folder_contents(self, browser):
         """Check if we are able to remove files over folder_contents."""
-        self._auth_a()
+        browser.login(self.user_a).open(self.folder_a, view='folder_contents')
+        folder_contents.select(self.doc_a, self.doc_b)
+        folder_contents.form().find('Delete').click()
+        self.assertEqual(['Item(s) deleted.'], statusmessages.info_messages())
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/folder_contents')
-        self.browser.getControl("doc-a").selected = True
-        self.browser.getControl("doc-b").selected = True
-        self.browser.getControl(name="folder_delete:method").click()
-        self.assertIn('<dd>Item(s) deleted.</dd>', self.browser.contents)
-
-    def test_usera_cuts_docs_folder_contents(self):
+    @browsing
+    def test_usera_cuts_docs_folder_contents(self, browser):
         """Check if we are able to cut docs over folder_contents."""
-        self._auth_a()
+        browser.login(self.user_a).open(self.folder_a, view='folder_contents')
+        folder_contents.select(self.doc_a, self.doc_b)
+        folder_contents.form().find('Cut').click()
+        self.assertEqual({'info': ['2 item(s) cut.'],
+                          'warning': [],
+                          'error': []}, statusmessages.messages())
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/folder_contents')
-        self.browser.getControl("doc-a").selected = True
-        self.browser.getControl("doc-b").selected = True
-        self.browser.getControl(name="folder_cut:method").click()
-        self.assertNotIn('<dd>One or more items not moveable.</dd>',
-                         self.browser.contents)
-
-    def test_usera_renames_docs_folder_contents(self):
+    @browsing
+    def test_usera_renames_docs_folder_contents(self, browser):
         """Check if we are able to rename docs over folder_contents."""
-        self._auth_a()
+        browser.login(self.user_a).open(self.folder_a, view='folder_contents')
+        folder_contents.select(self.doc_a, self.doc_b)
+        folder_contents.form().find('Rename').click()
+        self.assertEqual('folder_rename_form', plone.view())
+        self.assertEqual('doc-a', browser.css('#doc-a_id').first.value)
+        self.assertEqual('doc-b', browser.css('#doc-b_id').first.value)
 
-        self.browser.open(
-            self.folder_a.absolute_url() + '/folder_contents')
-        self.browser.getControl("doc-a").selected = True
-        self.browser.getControl("doc-b").selected = True
-        self.browser.getControl(name="folder_rename_form:method").click()
-
-        self.assertEquals(self.browser.contents.count('paths:list'), 2)
-
-    def test_userb_remove_docs_folder_contents(self):
+    @browsing
+    def test_userb_remove_docs_folder_contents(self, browser):
         """Check if the permission also works when we delete over
         folder_contents.
         """
-        self._auth_b()
+        browser.login(self.user_b).open(self.folder_a, view='folder_contents')
+        folder_contents.select(self.doc_a, self.doc_b)
+        folder_contents.form().find('Delete').click()
+        self.assertEqual(
+            {'info': ['/plone/rootfolder/folder-a/doc-a'
+                      ' could not be deleted.'],
+             'warning': [],
+             'error': []}, statusmessages.messages())
 
-        self.browser.open(self.folder_a.absolute_url() + '/folder_contents')
-        self.browser.getControl("doc-a").selected = True
-        self.browser.getControl("doc-b").selected = True
-        self.browser.getControl(name="folder_delete:method").click()
-        self.assertIn('<dd>/plone/rootfolder/folder-a/doc-a could not be '
-                      'deleted.</dd>',
-                      self.browser.contents)
-
-    def test_userb_cuts_docs_folder_contents(self):
+    @browsing
+    def test_userb_cuts_docs_folder_contents(self, browser):
         """Check if the permission also works when we cut over
         folder_contents.
         """
-        self._auth_b()
+        browser.login(self.user_b).open(self.folder_a, view='folder_contents')
+        folder_contents.select(self.doc_a, self.doc_b)
+        folder_contents.form().find('Cut').click()
+        self.assertEqual({'info': [],
+                          'warning': [],
+                          'error': ['One or more items not moveable.']},
+                         statusmessages.messages())
 
-        self.browser.open(self.folder_a.absolute_url() + '/folder_contents')
-        self.browser.getControl("doc-a").selected = True
-        self.browser.getControl("doc-b").selected = True
-        self.browser.getControl(name="folder_cut:method").click()
-        self.assertIn('<dd>One or more items not moveable.</dd>',
-                      self.browser.contents)
-
-    def test_userb_renames_docs_folder_contents(self):
+    @browsing
+    def test_userb_renames_docs_folder_contents(self, browser):
         """Check if the permission also works when we rename over
         folder_contents.
         """
-        self._auth_b()
-
-        self.browser.open(self.folder_a.absolute_url() + '/folder_contents')
-        self.browser.getControl("doc-a").selected = True
-        self.browser.getControl("doc-b").selected = True
-        self.browser.getControl(name="folder_rename_form:method").click()
-
-        self.assertEquals(self.browser.contents.count('paths:list'), 1)
+        browser.login(self.user_b).open(self.folder_a, view='folder_contents')
+        folder_contents.select(self.doc_a, self.doc_b)
+        folder_contents.form().find('Rename').click()
+        self.assertEqual('folder_rename_form', plone.view())
+        self.assertEqual(
+            ['You are not allowed to modify the id of this item.',
+             'You are not allowed to modify the title of this item.'],
+            browser.css('#content fieldset .error span').text)
+        self.assertFalse(browser.css('#doc-a_id'))
+        self.assertEqual('doc-b', browser.css('#doc-b_id').first.value)

--- a/development.cfg
+++ b/development.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
 package-name = collective.deletepermission

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ tests_require = [
     'unittest2',
     'zope.configuration',
     'ftw.builder',
+    'ftw.testbrowser',
     'plone.app.dexterity',
     ]
 


### PR DESCRIPTION
All tests are refactored to use ftw.testbrowser and ftw.builder.
The integration testing layer is eliminated so that we only have a functional testing layer.
A new unit test base class shares testing helpers.