### PR TITLE
Synchronize delete permissions.

### DIFF
--- a/collective/deletepermission/profiles/default/metadata.xml
+++ b/collective/deletepermission/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1001</version>
+  <version>1002</version>
 </metadata>

--- a/collective/deletepermission/profiles/default/rolemap.xml
+++ b/collective/deletepermission/profiles/default/rolemap.xml
@@ -3,11 +3,20 @@
     <permissions>
 
         <permission name="Delete portal content" acquire="True">
+            <role name="Contributor" />
+            <role name="Site Administrator" />
             <role name="Manager" />
             <role name="Owner" />
             <role name="Editor" />
         </permission>
 
+        <!--
+            The idea is that all roles with "Delete objects" permission should
+            also have the "Delete portal content" permission in order to
+            actually be able to delete things.
+            This principle applies to the site root settings and may be changed
+            by workflows, depending on the use case.
+        -->
         <permission name="Delete objects" acquire="True">
             <role name="Contributor" />
             <role name="Site Administrator" />

--- a/collective/deletepermission/upgrades/configure.zcml
+++ b/collective/deletepermission/upgrades/configure.zcml
@@ -22,5 +22,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 1001 -> 1002 -->
+    <genericsetup:upgradeStep
+        title="Synchronize delete permission role settings for site root"
+        description=""
+        source="1001"
+        destination="1002"
+        handler="collective.deletepermission.upgrades.to1002.upgrade"
+        profile="collective.deletepermission:default"
+        />
 
 </configure>

--- a/collective/deletepermission/upgrades/to1002.py
+++ b/collective/deletepermission/upgrades/to1002.py
@@ -1,0 +1,29 @@
+from operator import itemgetter
+
+
+def upgrade(setup_context):
+    """
+    The idea is that all roles with "Delete objects" permission should
+    also have the "Delete portal content" permission in order to
+    actually be able to delete things.
+    This principle applies to the site root settings and may be changed
+    by workflows, depending on the use case.
+    """
+    site = setup_context.portal_url.getPortalObject()
+
+    # Make sure that all roles which have the "Delete objects" also have
+    # the "Delete portal content" role.
+    roles, acquire = get_permission_settings(site, 'Delete portal content')
+    for role in get_permission_settings(site, 'Delete objects')[0]:
+        if role not in roles:
+            roles.append(role)
+
+    site.manage_permission('Delete portal content', roles, acquire=acquire)
+
+
+def get_permission_settings(context, permission):
+    acquire = bool(context.permission_settings(permission)[0]['acquire'])
+    roles = map(itemgetter('name'),
+                filter(itemgetter('selected'),
+                       context.rolesOfPermission(permission)))
+    return roles, acquire

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Let roles with "Delete objects" also have "Delete portal content" on site root.
+  This is important in order to avoid errors such as seeing a delete action but
+  getting an error when using it. It does only affect the site root settings and
+  not any workflows. [jone]
 
 
 1.3.0 (2016-09-02)


### PR DESCRIPTION
Let roles with "Delete objects" also have "Delete portal content" on site root.
This is important in order to avoid errors such as seeing a delete action but
getting an error when using it. It does only affect the site root settings and
not any workflows.

--

The idea is that all roles with "Delete objects" permission should
also have the "Delete portal content" permission in order to
actually be able to delete things.
This principle applies to the site root settings and may be changed
by workflows, depending on the use case.

--

// @maethu @lukasgraf @buchi 