### PR TITLE
Let Site Administrators delete foreign content on site root.

### DIFF
--- a/collective/deletepermission/profiles/default/metadata.xml
+++ b/collective/deletepermission/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1001</version>
+  <version>1002</version>
 </metadata>

--- a/collective/deletepermission/profiles/default/rolemap.xml
+++ b/collective/deletepermission/profiles/default/rolemap.xml
@@ -3,6 +3,7 @@
     <permissions>
 
         <permission name="Delete portal content" acquire="True">
+            <role name="Site Administrator" />
             <role name="Manager" />
             <role name="Owner" />
             <role name="Editor" />

--- a/collective/deletepermission/upgrades/configure.zcml
+++ b/collective/deletepermission/upgrades/configure.zcml
@@ -22,5 +22,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <!-- 1001 -> 1002 -->
+    <genericsetup:upgradeStep
+        title="Let Site Administrators delete foreign content on site root."
+        description=""
+        source="1001"
+        destination="1002"
+        handler="collective.deletepermission.upgrades.to1002.upgrade"
+        profile="collective.deletepermission:default"
+        />
 
 </configure>

--- a/collective/deletepermission/upgrades/to1002.py
+++ b/collective/deletepermission/upgrades/to1002.py
@@ -1,0 +1,18 @@
+from operator import itemgetter
+
+
+def upgrade(setup_context):
+    site = setup_context.portal_url.getPortalObject()
+    roles, acquire = get_permission_settings(site, 'Delete portal content')
+    if 'Site Administrator' not in roles:
+        roles.append('Site Administrator')
+
+    site.manage_permission('Delete portal content', roles, acquire=acquire)
+
+
+def get_permission_settings(context, permission):
+    acquire = bool(context.permission_settings(permission)[0]['acquire'])
+    roles = map(itemgetter('name'),
+                filter(itemgetter('selected'),
+                       context.rolesOfPermission(permission)))
+    return roles, acquire

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Let Site Administrators delete foreign content on site root. [jone]
 
 
 1.3.0 (2016-09-02)


### PR DESCRIPTION
As Site Administartors usually have administrative duties, they should be able to delete content created by other users in most standard situations.
Therefore we make this the new default setting in collective.deletepermission.

@maethu @lukasgraf @buchi please take a look.