### PR TITLE
Replaced import of eNotSupported

### DIFF
--- a/collective/deletepermission/rename.py
+++ b/collective/deletepermission/rename.py
@@ -9,7 +9,6 @@ from App.Dialogs import MessageDialog
 from cgi import escape
 from OFS.CopySupport import absattr
 from OFS.CopySupport import CopyError
-from OFS.CopySupport import eNotSupported
 from OFS.event import ObjectWillBeMovedEvent
 from webdav.Lockable import ResourceLockedError
 from ZODB.POSException import ConflictError
@@ -53,7 +52,7 @@ def manage_renameObject(self, id, new_id, REQUEST=None):
         raise ResourceLockedError('Object "%s" is locked via WebDAV'
                                     % ob.getId())
     if not isRenameable(ob):
-        raise CopyError(eNotSupported % escape(id))
+        raise CopyError('Not Supported')
     self._verifyObjectPaste(ob)
 
     try:

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Replaced import of eNotSupported. [reinhardt]
 
 
 1.5.0 (2019-09-09)


### PR DESCRIPTION
Fixes instance startup on Plone 5.2.